### PR TITLE
Fix for release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,12 +7,11 @@ builds:
     ldflags:
       - -s -w -X github.com/litencatt/uniar.version={{.Version}} -X github.com/litencatt/uniar.commit={{.FullCommit}} -X github.com/litencatt/uniar.date={{.Date}} -X github.com/litencatt/uniar/version.Version={{.Version}}
     env:
-      - CGO_ENABLED=1
+      - CGO_ENABLED=0
     goos:
       - darwin
     goarch:
       - amd64
-      - arm64
     main: ./cmd/uniar/main.go
 archives:
   - id: uniar-archive

--- a/uniar.go
+++ b/uniar.go
@@ -1,4 +1,4 @@
-package version
+package uniar
 
 const Name string = "uniar"
 


### PR DESCRIPTION
fix build error 
```
  ⨯ build failed after 1s                    error=hook failed: go mod tidy: exit status 1; output: go: finding module for package github.com/litencatt/uniar
github.com/litencatt/uniar/cmd imports
        github.com/litencatt/uniar: can't request version "latest" of the main module (github.com/litencatt/uniar)
```