### PR TITLE
 FIX record registration error

### DIFF
--- a/cmd/registLive.go
+++ b/cmd/registLive.go
@@ -24,7 +24,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/Songmu/prompter"
 	"github.com/litencatt/uniar/repository"
@@ -37,13 +36,6 @@ var registLiveCmd = &cobra.Command{
 	Use:   "live",
 	Short: "Regist a live to database",
 	Run: func(cmd *cobra.Command, args []string) {
-		g := (&prompter.Prompter{
-			Choices: []string{"1", "2"},
-			Default: "1",
-			Message: "Select Group(1:櫻坂46 2:日向坂46)",
-		}).Prompt()
-		groupId, _ := strconv.Atoi(g)
-
 		liveName := (&prompter.Prompter{
 			Message: "Live name",
 		}).Prompt()
@@ -63,11 +55,7 @@ var registLiveCmd = &cobra.Command{
 			return
 		}
 
-		gn := "櫻坂46"
-		if groupId == 2 {
-			gn = "日向坂46"
-		}
-		fmt.Printf("success registration(GroupName:%s LiveName:%s)\n", gn, liveName)
+		fmt.Printf("success registration(LiveName:%s)\n", liveName)
 	},
 }
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,142 +1,129 @@
 CREATE TABLE center_skills (
-  id int NOT NULL,
+  id integer PRIMARY KEY AUTOINCREMENT,
   name varchar(100) NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (id)
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE color_types (
-  id int NOT NULL,
+  id integer PRIMARY KEY AUTOINCREMENT,
   name varchar(100) NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (id)
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE groups (
-  id int NOT NULL ,
+  id integer PRIMARY KEY AUTOINCREMENT,
   name varchar(100) NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (id)
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE lives (
-  id int NOT NULL ,
+  id integer PRIMARY KEY AUTOINCREMENT,
   name varchar(100) NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (id)
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE members (
-  id int NOT NULL ,
+  id integer PRIMARY KEY AUTOINCREMENT,
   name varchar(100) NOT NULL,
   first_name varchar(100) DEFAULT NULL,
-  group_id int NOT NULL,
-  phase int NOT NULL,
-  graduated int NOT NULL DEFAULT '0',
+  group_id integer NOT NULL,
+  phase integer NOT NULL,
+  graduated integer NOT NULL DEFAULT '0',
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (id),
   CONSTRAINT Member_ibfk_1 FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE TABLE music (
-  id int NOT NULL ,
+  id integer PRIMARY KEY AUTOINCREMENT,
   name varchar(100) NOT NULL,
-  normal int NOT NULL,
-  pro int NOT NULL,
-  master int NOT NULL,
-  length int NOT NULL,
-  color_type_id int NOT NULL,
-  live_id int NOT NULL,
-  pro_plus int DEFAULT NULL,
-  music_bonus int DEFAULT '0',
-  setlist_id int DEFAULT NULL,
+  normal integer NOT NULL,
+  pro integer NOT NULL,
+  master integer NOT NULL,
+  length integer NOT NULL,
+  color_type_id integer NOT NULL,
+  live_id integer NOT NULL,
+  pro_plus integer DEFAULT NULL,
+  music_bonus integer DEFAULT '0',
+  setlist_id integer DEFAULT NULL,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (id),
   CONSTRAINT Music_ibfk_1 FOREIGN KEY (live_id) REFERENCES lives (id) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT Music_ibfk_2 FOREIGN KEY (color_type_id) REFERENCES color_types (id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE TABLE photograph (
-  id int NOT NULL ,
+  id integer PRIMARY KEY AUTOINCREMENT,
   name varchar(100) NOT NULL,
-  group_id int NOT NULL,
+  group_id integer NOT NULL,
   abbreviation varchar(10) NOT NULL DEFAULT '',
   photo_type varchar(10) NOT NULL,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (id),
   CONSTRAINT Photograph_ibfk_1 FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE TABLE scenes (
-  id int NOT NULL ,
-  photograph_id int NOT NULL,
-  member_id int NOT NULL,
-  color_type_id int NOT NULL,
-  vocal_max int NOT NULL,
-  dance_max int NOT NULL,
-  peformance_max int NOT NULL,
+  id integer PRIMARY KEY AUTOINCREMENT,
+  photograph_id integer NOT NULL,
+  member_id integer NOT NULL,
+  color_type_id integer NOT NULL,
+  vocal_max integer NOT NULL,
+  dance_max integer NOT NULL,
+  peformance_max integer NOT NULL,
   center_skill_name varchar(100)  DEFAULT NULL,
   expected_value varchar(5)  DEFAULT NULL,
-  ssr_plus int NOT NULL DEFAULT '0',
+  ssr_plus integer NOT NULL DEFAULT '0',
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (id),
   CONSTRAINT Scene_ibfk_2 FOREIGN KEY (member_id) REFERENCES members (id) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT Scene_ibfk_3 FOREIGN KEY (photograph_id) REFERENCES photograph (id) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT Scene_ibfk_5 FOREIGN KEY (color_type_id) REFERENCES color_types (id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE TABLE skills (
-  id int NOT NULL ,
+  id integer PRIMARY KEY AUTOINCREMENT,
   name varchar(100) NOT NULL,
-  combo_up_percent int DEFAULT NULL,
-  duration_sec int DEFAULT NULL,
+  combo_up_percent integer DEFAULT NULL,
+  duration_sec integer DEFAULT NULL,
   expected_value double NOT NULL,
-  interval_sec int NOT NULL,
-  occurrence_percent int NOT NULL,
-  score_up_percent int DEFAULT NULL,
-  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (id)
+  interval_sec integer NOT NULL,
+  occurrence_percent integer NOT NULL,
+  score_up_percent integer DEFAULT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE producers (
-  id int NOT NULL ,
-  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (id)
+  id integer PRIMARY KEY AUTOINCREMENT,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE producer_scenes (
-  id int NOT NULL ,
-  producer_id INT NOT NULL,
-  photograph_id INT NOT NULL,
-  member_id INT NOT NULL,
-  have INT DEFAULT 0,
+  id integer PRIMARY KEY AUTOINCREMENT,
+  producer_id integer NOT NULL,
+  photograph_id integer NOT NULL,
+  member_id integer NOT NULL,
+  have integer DEFAULT 0,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (id),
   CONSTRAINT fk_producer_scenes_producer_id FOREIGN KEY (producer_id) REFERENCES producers (id),
   CONSTRAINT fk_producer_scenes_photo_id FOREIGN KEY (photograph_id) REFERENCES photograph (id),
   CONSTRAINT fk_producer_scenes_member_id FOREIGN KEY (member_id) REFERENCES members (id)
 );
 
 CREATE TABLE producer_members (
-  id int NOT NULL ,
-  producer_id INT NOT NULL,
-  member_id INT NOT NULL,
-  bond_level_curent INT NOT NULL,
-  bond_level_collection_max INT NOT NULL,
-  bond_level_scene_max INT NOT NULL,
-  discography_disc_total INT NOT NULL,
-  discography_disc_total_max INT NOT NULL,
+  id integer PRIMARY KEY AUTOINCREMENT,
+  producer_id integer NOT NULL,
+  member_id integer NOT NULL,
+  bond_level_curent integer NOT NULL,
+  bond_level_collection_max integer NOT NULL,
+  bond_level_scene_max integer NOT NULL,
+  discography_disc_total integer NOT NULL,
+  discography_disc_total_max integer NOT NULL,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (id),
   CONSTRAINT fk_producer_members_producer_id FOREIGN KEY (producer_id) REFERENCES producers (id),
   CONSTRAINT fk_producer_members_member_id FOREIGN KEY (member_id) REFERENCES members (id)
 );
 
 CREATE TABLE producer_offices (
-  id int NOT NULL ,
-  producer_id INT NOT NULL,
-  office_bonus INT DEFAULT 0,
+  id integer PRIMARY KEY AUTOINCREMENT,
+  producer_id integer NOT NULL,
+  office_bonus integer DEFAULT 0,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (id),
   CONSTRAINT fk_producer_offices_producer_id FOREIGN KEY (producer_id) REFERENCES producers (id)
 );


### PR DESCRIPTION
To FIX record registration error.
```
sqlite> INSERT INTO  "photograph" ("name", "group_id", "photo_type") VALUES ('foo', '1', '限定');
Error: stepping, NOT NULL constraint failed: photograph.id (19)
```

Set `  id integer PRIMARY KEY AUTOINCREMENT` to id column for sqlite3 to autoincrementable.