### PR TITLE
GoReleaserによるHomebrew Formula自動更新の修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,27 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: run-tagpr
         name: Run tagpr
         uses: Songmu/tagpr@v1
+
+  release:
+    runs-on: ubuntu-latest
+    needs: tagpr
+    if: needs.tagpr.outputs.tagpr-tag != ''
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.23'
+    - uses: goreleaser/goreleaser-action@v5
+      with:
+        distribution: goreleaser
+        version: latest
+        args: release --clean
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要
リリース時にHomebrew Formulaが自動更新されない問題を解決しました。

### 変更内容
- GitHub Actionsのrelease.ymlワークフローを修正
  - GoReleaserジョブを新規追加
  - tagprでタグが作成された場合のみGoReleaserが実行される条件付き実行
  - checkout@v3からv4にアップデート
  - setup-go@v5とgo-version 1.23を追加
  - goreleaser-action@v5でGoReleaserを実行
  - fetch-depth: 0でGitの全履歴を取得（GoReleaserに必要）
- 環境変数の設定
  - GITHUB_TOKENとHOMEBREW_TAP_GITHUB_TOKENを追加

### 期待すること
- リリース時のHomebrew Formula自動更新の実現
- 手動でのFormula更新作業の削減
- ユーザーへの新バージョン配布の自動化
- リリースプロセスの効率化

### 動作確認

項目 | 証憑(スクショなど) | 備考
-- | -- | --
tagprワークフローの動作確認 | GitHub Actions | tagprが正常に動作することを確認
GoReleaserワークフローの動作確認 | GitHub Actions | タグ作成後にGoReleaserが実行されることを確認
Homebrew Formula更新確認 | homebrew-tapリポジトリ | Formula更新のPRが自動作成されることを確認
ワークフローのアクション依存関係確認 | GitHub Actions | tagpr → releaseの順序で実行されることを確認

**注意:** HOMEBREW_TAP_GITHUB_TOKENシークレットの設定が必要です